### PR TITLE
SWARM-1604: Align versions with depMan import of parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
     <module>client</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-parent</artifactId>
+        <version>${version.keycloak}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>


### PR DESCRIPTION
Motivation
----------
Needed to provide way for aligning versions.

Modifications
-------------
Add keycloak-parent into depMan.

Result
------
Doesn't impact product, just aligns build.